### PR TITLE
feat!: Create `checkCoverage` and `perFile` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Create `nyc.config.js` in your project:
 'use strict';
 
 module.exports = require('@cfware/nyc')
-  .fullCoverage()
+  .all()
+  .checkCoverage()
   .exclude('build/**');
 ```
 

--- a/index.cjs
+++ b/index.cjs
@@ -8,12 +8,14 @@ const settings = Symbol.for('nycrc');
 class NYCConfigBase {
 	constructor(customSettings = {}) {
 		this[settings] = {
-			all: true,
 			tempDir: 'coverage/.nyc_output',
 			require: [],
 			include: [],
 			exclude: [...NYCConfigBase.defaultExclude],
-			excludeNodeModules: true,
+			lines: 100,
+			statements: 100,
+			functions: 100,
+			branches: 100,
 			...customSettings
 		};
 	}
@@ -33,21 +35,20 @@ class NYCConfigBase {
 }
 
 class NYCConfig extends NYCConfigBase {
-	all(enable = false) {
+	all(enable = true) {
 		this[settings].all = enable;
 
 		return this;
 	}
 
-	fullCoverage(perFile = true) {
-		Object.assign(this[settings], {
-			checkCoverage: true,
-			perFile,
-			lines: 100,
-			statements: 100,
-			functions: 100,
-			branches: 100
-		});
+	checkCoverage(enable = true) {
+		this[settings].checkCoverage = enable;
+
+		return this;
+	}
+
+	perFile(enable = true) {
+		this[settings].perFile = enable;
 
 		return this;
 	}
@@ -70,7 +71,7 @@ class NYCConfig extends NYCConfigBase {
 		return this;
 	}
 
-	excludeNodeModules(exclude = false) {
+	excludeNodeModules(exclude = true) {
 		this[settings].excludeNodeModules = exclude;
 
 		return this;

--- a/nyc-report-config.cjs
+++ b/nyc-report-config.cjs
@@ -1,5 +1,4 @@
 'use strict';
 
 module.exports = require('./index.cjs')
-	.all(false)
-	.fullCoverage();
+	.all(false);

--- a/tap-snapshots/test.cjs-TAP.test.cjs
+++ b/tap-snapshots/test.cjs-TAP.test.cjs
@@ -8,21 +8,27 @@
 exports[`test.cjs TAP all > false 1`] = `
 Object {
   "all": false,
+  "branches": 100,
   "exclude": Array [],
-  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP all > no arg 1`] = `
 Object {
-  "all": false,
+  "all": true,
+  "branches": 100,
   "exclude": Array [],
-  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
@@ -30,79 +36,163 @@ Object {
 exports[`test.cjs TAP all > true 1`] = `
 Object {
   "all": true,
+  "branches": 100,
   "exclude": Array [],
-  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "require": Array [],
+  "statements": 100,
+  "tempDir": "coverage/.nyc_output",
+}
+`
+
+exports[`test.cjs TAP checkCoverage > false 1`] = `
+Object {
+  "branches": 100,
+  "checkCoverage": false,
+  "exclude": Array [],
+  "functions": 100,
+  "include": Array [],
+  "lines": 100,
+  "require": Array [],
+  "statements": 100,
+  "tempDir": "coverage/.nyc_output",
+}
+`
+
+exports[`test.cjs TAP checkCoverage > no arg 1`] = `
+Object {
+  "branches": 100,
+  "checkCoverage": true,
+  "exclude": Array [],
+  "functions": 100,
+  "include": Array [],
+  "lines": 100,
+  "require": Array [],
+  "statements": 100,
+  "tempDir": "coverage/.nyc_output",
+}
+`
+
+exports[`test.cjs TAP checkCoverage > true 1`] = `
+Object {
+  "branches": 100,
+  "checkCoverage": true,
+  "exclude": Array [],
+  "functions": 100,
+  "include": Array [],
+  "lines": 100,
+  "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP exclude > file1.js and file2.js 1`] = `
 Object {
-  "all": true,
+  "branches": 100,
   "exclude": Array [
     "file1.js",
     "file2.js",
   ],
-  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP exclude > no arg 1`] = `
 Object {
-  "all": true,
+  "branches": 100,
   "exclude": Array [],
-  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP excludeNodeModules > false 1`] = `
 Object {
-  "all": true,
+  "branches": 100,
   "exclude": Array [],
   "excludeNodeModules": false,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP excludeNodeModules > no arg 1`] = `
 Object {
-  "all": true,
+  "branches": 100,
   "exclude": Array [],
-  "excludeNodeModules": false,
+  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP excludeNodeModules > true 1`] = `
 Object {
-  "all": true,
+  "branches": 100,
   "exclude": Array [],
   "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
-exports[`test.cjs TAP fullCoverage > false 1`] = `
+exports[`test.cjs TAP include > file1.js and file2.js 1`] = `
 Object {
-  "all": true,
   "branches": 100,
-  "checkCoverage": true,
   "exclude": Array [],
-  "excludeNodeModules": true,
+  "functions": 100,
+  "include": Array [
+    "file1.js",
+    "file2.js",
+  ],
+  "lines": 100,
+  "require": Array [],
+  "statements": 100,
+  "tempDir": "coverage/.nyc_output",
+}
+`
+
+exports[`test.cjs TAP include > no arg 1`] = `
+Object {
+  "branches": 100,
+  "exclude": Array [],
+  "functions": 100,
+  "include": Array [],
+  "lines": 100,
+  "require": Array [],
+  "statements": 100,
+  "tempDir": "coverage/.nyc_output",
+}
+`
+
+exports[`test.cjs TAP perFile > false 1`] = `
+Object {
+  "branches": 100,
+  "exclude": Array [],
   "functions": 100,
   "include": Array [],
   "lines": 100,
@@ -113,13 +203,10 @@ Object {
 }
 `
 
-exports[`test.cjs TAP fullCoverage > no arg 1`] = `
+exports[`test.cjs TAP perFile > no arg 1`] = `
 Object {
-  "all": true,
   "branches": 100,
-  "checkCoverage": true,
   "exclude": Array [],
-  "excludeNodeModules": true,
   "functions": 100,
   "include": Array [],
   "lines": 100,
@@ -130,110 +217,92 @@ Object {
 }
 `
 
-exports[`test.cjs TAP fullCoverage > true 1`] = `
+exports[`test.cjs TAP perFile > true 1`] = `
 Object {
-  "all": true,
   "branches": 100,
-  "checkCoverage": true,
   "exclude": Array [],
-  "excludeNodeModules": true,
   "functions": 100,
   "include": Array [],
   "lines": 100,
   "perFile": true,
   "require": Array [],
   "statements": 100,
-  "tempDir": "coverage/.nyc_output",
-}
-`
-
-exports[`test.cjs TAP include > file1.js and file2.js 1`] = `
-Object {
-  "all": true,
-  "exclude": Array [],
-  "excludeNodeModules": true,
-  "include": Array [
-    "file1.js",
-    "file2.js",
-  ],
-  "require": Array [],
-  "tempDir": "coverage/.nyc_output",
-}
-`
-
-exports[`test.cjs TAP include > no arg 1`] = `
-Object {
-  "all": true,
-  "exclude": Array [],
-  "excludeNodeModules": true,
-  "include": Array [],
-  "require": Array [],
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP reporter > no arg 1`] = `
 Object {
-  "all": true,
+  "branches": 100,
   "exclude": Array [],
-  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "reporter": Array [],
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP reporter > text 1`] = `
 Object {
-  "all": true,
+  "branches": 100,
   "exclude": Array [],
-  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "reporter": Array [
     "text",
   ],
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP reporter > text and html 1`] = `
 Object {
-  "all": true,
+  "branches": 100,
   "exclude": Array [],
-  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "reporter": Array [
     "text",
     "html",
   ],
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP require > esm and babel 1`] = `
 Object {
-  "all": true,
+  "branches": 100,
   "exclude": Array [],
-  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "require": Array [
     "esm",
     "@babel/register",
   ],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `
 
 exports[`test.cjs TAP require > no arg 1`] = `
 Object {
-  "all": true,
+  "branches": 100,
   "exclude": Array [],
-  "excludeNodeModules": true,
+  "functions": 100,
   "include": Array [],
+  "lines": 100,
   "require": Array [],
+  "statements": 100,
   "tempDir": "coverage/.nyc_output",
 }
 `

--- a/test.cjs
+++ b/test.cjs
@@ -62,9 +62,9 @@ t.test('basics', async t => {
 	t.same((await object).exclude, []);
 });
 
-test('all', booleanValueTest);
-
-test('fullCoverage', booleanValueTest);
+for (const id of ['all', 'checkCoverage', 'perFile', 'excludeNodeModules']) {
+	test(id, booleanValueTest);
+}
 
 test('require', stringValuesTest, {
 	'esm and babel': ['esm', '@babel/register']
@@ -82,5 +82,3 @@ test('reporter', stringValuesTest, {
 	text: ['text'],
 	'text and html': ['text', 'html']
 });
-
-test('excludeNodeModules', booleanValueTest);


### PR DESCRIPTION
BREAKING CHANGE: The `fullCoverage` method is removed
BREAKING CHANGE: The default for `all` is now false
BREAKING CHANGE: The default argument to `all` and `excludeNodeModules`
methods are now `true`